### PR TITLE
fix: balance query with custom transaction model

### DIFF
--- a/spec/balance.spec.ts
+++ b/spec/balance.spec.ts
@@ -225,8 +225,11 @@ describe("balance model", function () {
       expect(res.results[0].meta).to.have.property("otherMeta");
       expect(res.results[0].meta).to.not.have.property("clientId");
 
-      const snapshot = await getBestSnapshot({ book: book.name, account, clientId, otherMeta });
-      expect(snapshot).to.have.property("balance", 1);
+      const snapshot1 = await getBestSnapshot({ book: book.name, account, clientId, meta: { otherMeta } });
+      expect(snapshot1).to.have.property("balance", 1);
+
+      const snapshot2 = await getBestSnapshot({ book: book.name, account, clientId, otherMeta });
+      expect(snapshot2).to.have.property("balance", 1);
     });
   });
 });

--- a/spec/helper/transactionSchema.ts
+++ b/spec/helper/transactionSchema.ts
@@ -1,0 +1,65 @@
+import { Schema, Types } from "mongoose";
+import { IAnyObject } from "../../src/IAnyObject";
+
+export interface ITransactionTest {
+  _id?: Types.ObjectId;
+  credit: number;
+  debit: number;
+  meta?: IAnyObject;
+  datetime: Date;
+  account_path: string[];
+  accounts: string;
+  book: string;
+  memo: string;
+  _journal: Types.ObjectId;
+  timestamp: Date;
+  voided?: boolean;
+  void_reason?: string;
+  _original_journal?: Types.ObjectId;
+
+  // custom attributes
+  _journal2: Types.ObjectId;
+  clientId?: string;
+}
+
+export function getTransactionSchemaTest() {
+  const transactionSchemaTest = new Schema<ITransactionTest>(
+    {
+      credit: Number,
+      debit: Number,
+      meta: Schema.Types.Mixed,
+      datetime: Date,
+      account_path: [String],
+      accounts: String,
+      book: String,
+      memo: String,
+      _journal: {
+        type: Schema.Types.ObjectId,
+        ref: "Medici_Journal",
+      },
+      timestamp: Date,
+      voided: Boolean,
+      void_reason: String,
+      // The journal that this is voiding, if any
+      _original_journal: {
+        type: Schema.Types.ObjectId,
+        ref: "Medici_Journal",
+      },
+
+      // custom attributes
+      _journal2: {
+        type: Schema.Types.ObjectId,
+        ref: "Medici_Journal",
+      },
+      clientId: String,
+    },
+    { id: false, versionKey: false, timestamps: false }
+  );
+
+  transactionSchemaTest.index({
+    voided: 1,
+    void_reason: 1,
+  });
+
+  return transactionSchemaTest;
+}

--- a/spec/parseFilterQuery.spec.ts
+++ b/spec/parseFilterQuery.spec.ts
@@ -67,7 +67,12 @@ describe("parseFilterQuery", () => {
     const clientId = "619af485cd56547936847584";
     let bookmarked = true;
     const result1 = parseBalanceQuery({ clientId, bookmarked }, { name: "MyBook" });
-    expect(result1).to.deep.equal({ book: "MyBook", meta: { clientId, bookmarked } });
+    expect(result1).to.deep.equal({
+      book: "MyBook",
+      "meta.bookmarked": bookmarked,
+      "meta.clientId": clientId,
+      meta: { clientId, bookmarked },
+    });
 
     bookmarked = false;
     const _someOtherDatabaseId = "619af485cd56547936847584";

--- a/spec/setTransactionSchema.spec.ts
+++ b/spec/setTransactionSchema.spec.ts
@@ -1,28 +1,9 @@
 /* eslint sonarjs/no-duplicate-string: off */
 import { expect } from "chai";
-import { Schema, Types } from "mongoose";
+import { Types } from "mongoose";
 import { Book, syncIndexes } from "../src";
-import { IAnyObject } from "../src/IAnyObject";
-import { IJournal } from "../src/models/journal";
 import { setTransactionSchema, transactionModel, transactionSchema } from "../src/models/transaction";
-
-export interface ITransactionNew {
-  _id: Types.ObjectId;
-  credit: number;
-  debit: number;
-  meta: IAnyObject;
-  datetime: Date;
-  account_path: string[];
-  accounts: string;
-  book: string;
-  memo: string;
-  _journal: Types.ObjectId | IJournal;
-  _journal2: Types.ObjectId | IJournal;
-  timestamp: Date;
-  voided: boolean;
-  void_reason?: string;
-  _original_journal?: Types.ObjectId;
-}
+import { getTransactionSchemaTest, ITransactionTest } from "./helper/transactionSchema";
 
 describe("setTransactionSchema", () => {
   it("should return full ledger with _journal2", async function () {
@@ -30,42 +11,9 @@ describe("setTransactionSchema", () => {
     await syncIndexes({ background: false });
 
     try {
-      const newTransactionSchema = new Schema<ITransactionNew>(
-        {
-          credit: Number,
-          debit: Number,
-          meta: Schema.Types.Mixed,
-          datetime: Date,
-          account_path: [String],
-          accounts: String,
-          book: String,
-          memo: String,
-          _journal: {
-            type: Schema.Types.ObjectId,
-            ref: "Medici_Journal",
-          },
-          _journal2: {
-            type: Schema.Types.ObjectId,
-            ref: "Medici_Journal",
-          },
-          timestamp: Date,
-          voided: {
-            type: Boolean,
-            default: false,
-          },
-          void_reason: String,
-          // The journal that this is voiding, if any
-          _original_journal: Schema.Types.ObjectId,
-        },
-        { id: false, versionKey: false, timestamps: false }
-      );
+      const transactionSchemaTest = getTransactionSchemaTest();
 
-      newTransactionSchema.index({
-        voided: 1,
-        void_reason: 1,
-      });
-
-      setTransactionSchema(newTransactionSchema, undefined, {
+      setTransactionSchema(transactionSchemaTest, undefined, {
         defaultIndexes: false,
       });
 
@@ -76,7 +24,7 @@ describe("setTransactionSchema", () => {
         void_reason: 1,
       });
 
-      const book = new Book<ITransactionNew>("MyBook-TransactionSchema");
+      const book = new Book<ITransactionTest>("MyBook-TransactionSchema");
 
       const journal = await book
         .entry("Test")

--- a/src/Book.ts
+++ b/src/Book.ts
@@ -8,7 +8,6 @@ import {
 } from "./errors";
 import { handleVoidMemo } from "./helper/handleVoidMemo";
 import { addReversedTransactions } from "./helper/addReversedTransactions";
-import { flattenObject } from "./helper/flattenObject";
 import { IPaginationQuery, IFilterQuery, parseFilterQuery } from "./helper/parse/parseFilterQuery";
 import { IBalanceQuery, parseBalanceQuery } from "./helper/parse/parseBalanceQuery";
 import { Entry } from "./Entry";
@@ -98,9 +97,7 @@ export class Book<U extends ITransaction = ITransaction, J extends IJournal = IJ
       }
     }
 
-    const match = {
-      $match: { ...parsedQuery, ...flattenObject(meta, "meta") },
-    };
+    const match = { $match: parsedQuery };
 
     const result = (await transactionModel.collection.aggregate([match, GROUP], options).toArray())[0];
 
@@ -139,9 +136,7 @@ export class Book<U extends ITransaction = ITransaction, J extends IJournal = IJ
           // If it's too old we would need to cache another snapshot.
           if (tooOld) {
             delete parsedQuery._id;
-            const match = {
-              $match: { ...parsedQuery, ...flattenObject(meta, "meta") },
-            };
+            const match = { $match: parsedQuery };
 
             // Important! We are going to recalculate the entire balance from the day one.
             // Since this operation can take seconds (if you have millions of documents)
@@ -326,8 +321,8 @@ export class Book<U extends ITransaction = ITransaction, J extends IJournal = IJ
     );
     const uniqueAccounts: Set<string> = new Set();
     for (const result of results) {
-      const prev = [];
-      const paths = result.split(":");
+      const prev: string[] = [];
+      const paths: string[] = result.split(":");
       for (const acct of paths) {
         prev.push(acct);
         uniqueAccounts.add(prev.join(":"));

--- a/src/models/balance.ts
+++ b/src/models/balance.ts
@@ -94,7 +94,8 @@ export async function snapshotBalance(
 }
 
 export function getBestSnapshot(query: FilterQuery<IBalance>, options: IOptions = {}): Promise<IBalance | null> {
-  const key = constructKey(query.book, query.account, query.meta);
+  const { book, account, meta, ...extras } = query;
+  const key = constructKey(book, account, { ...meta, ...extras });
   return balanceModel.collection.findOne(
     { key },
     { sort: { _id: -1 }, session: options.session }


### PR DESCRIPTION
### Problem
Custom schema attributes are not setup correctly for balance query

### Solution
 - Use `parseFilterQuery` logic
 - Keep `meta` attribute only for snapshot related methods

Maybe not the cleaner solution but doesn't change other collections schema/behavior 

---
Related issue: https://github.com/flash-oss/medici/issues/58