### PR TITLE
fix: constructKey meta data mapping

### DIFF
--- a/spec/constructKey.spec.ts
+++ b/spec/constructKey.spec.ts
@@ -1,0 +1,23 @@
+import { expect } from "chai";
+import { constructKey } from "../src/models/balance";
+
+describe("constructKey", () => {
+  it("should handle empty account and meta correctly", () => {
+    const result = constructKey("MyBook");
+    expect(result).to.be.equal("MyBook");
+  });
+
+  it("should handle empty meta correctly", () => {
+    const result = constructKey("MyBook", "Account");
+    expect(result).to.be.equal("MyBook;Account");
+  });
+
+  it("should handle meta correctly", () => {
+    const resultkey = "MyBook;Account;clientId.$in.0:12345,clientId.$in.1:67890,currency:USD";
+    const result = constructKey("MyBook", "Account", { currency: "USD", clientId: { $in: ["12345", "67890"] } });
+    expect(result).to.be.equal(resultkey);
+
+    const result1 = constructKey("MyBook", "Account", { clientId: { $in: ["12345", "67890"] }, currency: "USD" });
+    expect(result1).to.be.equal(resultkey);
+  });
+});

--- a/spec/constructKey.spec.ts
+++ b/spec/constructKey.spec.ts
@@ -1,19 +1,22 @@
+import { createHash } from "crypto";
 import { expect } from "chai";
 import { constructKey } from "../src/models/balance";
+
+const createHashKey = (key: string) => createHash("sha1").update(key).digest().toString("latin1");
 
 describe("constructKey", () => {
   it("should handle empty account and meta correctly", () => {
     const result = constructKey("MyBook");
-    expect(result).to.be.equal("MyBook");
+    expect(result).to.be.equal(createHashKey("MyBook"));
   });
 
   it("should handle empty meta correctly", () => {
     const result = constructKey("MyBook", "Account");
-    expect(result).to.be.equal("MyBook;Account");
+    expect(result).to.be.equal(createHashKey("MyBook;Account"));
   });
 
   it("should handle meta correctly", () => {
-    const resultkey = "MyBook;Account;clientId.$in.0:12345,clientId.$in.1:67890,currency:USD";
+    const resultkey = createHashKey("MyBook;Account;clientId.$in.0:12345,clientId.$in.1:67890,currency:USD");
     const result = constructKey("MyBook", "Account", { currency: "USD", clientId: { $in: ["12345", "67890"] } });
     expect(result).to.be.equal(resultkey);
 

--- a/src/models/balance.ts
+++ b/src/models/balance.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import { Schema, model, Model, connection, Types, FilterQuery } from "mongoose";
 import type { IAnyObject } from "../IAnyObject";
 import type { IOptions } from "../IOptions";
@@ -49,7 +50,7 @@ export function constructKey(book: string, account?: string, meta?: IAnyObject):
   // Example of a simple key: "My book;Liabilities:12345"
   // Example of a complex key: "My book;Liabilities:Client,Liabilities:Client Pending;clientId.$in.0:12345,clientId.$in.1:67890"
 
-  return [
+  const key = [
     book,
     account,
     Object.entries(flattenObject(meta, "", true))
@@ -59,6 +60,8 @@ export function constructKey(book: string, account?: string, meta?: IAnyObject):
   ]
     .filter(Boolean)
     .join(";");
+
+  return createHash("sha1").update(key).digest().toString("latin1");
 }
 
 export async function snapshotBalance(

--- a/src/models/balance.ts
+++ b/src/models/balance.ts
@@ -53,6 +53,7 @@ export function constructKey(book: string, account?: string, meta?: IAnyObject):
     book,
     account,
     Object.entries(flattenObject(meta, "", true))
+      .sort()
       .map(([key, value]) => key + ":" + value)
       .join(),
   ]


### PR DESCRIPTION
This is a bug found in https://github.com/flash-oss/medici/pull/59 (need to be solved before merge) ~and is a potential breaking change to current implementations of this version~

### Problem

balance `constructKey` does not map correctly the meta object. passing `{ param1, param2 }` and `{ param2, param1 }` create a different key (balance snapshot will not return a valid value)

### Solution

add `.sort` before meta mapping