### PR TITLE
fix: package dependencies for `ts-mocha` and `eslint-plugin-promise`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1589,9 +1589,9 @@
       }
     },
     "eslint-plugin-promise": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.2.0.tgz",
-      "integrity": "sha512-SftLb1pUG01QYq2A/hGAWfDRXqYD82zE7j7TopDOyNdU+7SvvoXREls/+PRTY17vUXzXnZA/zfnyKgRH6x4JJw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.0.tgz",
+      "integrity": "sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==",
       "dev": true
     },
     "eslint-plugin-security": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2699,12 +2699,12 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.6"
       }
     },
     "mocha": {
@@ -3969,9 +3969,9 @@
       "dev": true
     },
     "ts-mocha": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/ts-mocha/-/ts-mocha-8.0.0.tgz",
-      "integrity": "sha512-Kou1yxTlubLnD5C3unlCVO7nh0HERTezjoVhVw/M5S1SqoUec0WgllQvPk3vzPMc6by8m6xD1uR1yRf8lnVUbA==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/ts-mocha/-/ts-mocha-9.0.2.tgz",
+      "integrity": "sha512-WyQjvnzwrrubl0JT7EC1yWmNpcsU3fOuBFfdps30zbmFBgKniSaSOyZMZx+Wq7kytUs5CY+pEbSYEbGfIKnXTw==",
       "dev": true,
       "requires": {
         "ts-node": "7.0.1",
@@ -4299,7 +4299,7 @@
     "yn": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+      "integrity": "sha512-uTv8J/wiWTgUTg+9vLTi//leUl5vDQS6uii/emeTb2ssY7vl6QWf2fFbIIGjnhjvbdKlU0ed7QPgY1htTC86jQ==",
       "dev": true
     },
     "yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "prettier": "^2.5.1",
     "rimraf": "^3.0.2",
     "sinon": "^12.0.1",
-    "ts-mocha": "^8.0.0",
+    "ts-mocha": "^9.0.2",
     "tsd": "^0.19.0",
     "typescript": "^4.5.4"
   },

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "dts-bundle-generator": "^6.2.0",
     "eslint": "^8.4.1",
     "eslint-plugin-import": "^2.25.3",
-    "eslint-plugin-promise": "^5.2.0",
+    "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-security": "^1.4.0",
     "eslint-plugin-security-node": "^1.0.14",
     "eslint-plugin-sonarjs": "^0.11.0",


### PR DESCRIPTION
`ts-mocha` and `eslint-plugin-promise` contain invalid versions producing npm warnings and errors.

Error Message:
```
npx npm@6 list --depth 1
...
npm ERR! peer dep missing: eslint@^7.0.0, required by eslint-plugin-promise@5.2.0
npm ERR! peer dep missing: mocha@^3.X.X || ^4.X.X || ^5.X.X || ^6.X.X || ^7.X.X || ^8.X.X, required by ts-mocha@8.0.0
```

After any install command:
```
npm WARN eslint-plugin-promise@5.2.0 requires a peer of eslint@^7.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN ts-mocha@8.0.0 requires a peer of mocha@^3.X.X || ^4.X.X || ^5.X.X || ^6.X.X || ^7.X.X || ^8.X.X but none is installed. You must install peer dependencies yourself.
```

**To reproduce this pull request you can run the following commands:**

```
$ npx npm@6 install ts-mocha@^9.0.0
$ npx npm@6 install eslint-plugin-promise@^6.0.0
```