### PR TITLE
feat: add mongoose v9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ jobs:
   test:
     name: Node ${{ matrix.node }}, Mongo ${{ matrix.mongodb-version }}, on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -30,4 +31,6 @@ jobs:
       - run: npm run ci-mongoose6
       - run: npm run ci-mongoose7
       - run: npm run ci-mongoose8
-      - run: npm run ci-mongoose9
+      # mongoose 9 requires Node >= 20, so skip this step on older Node versions
+      - if: matrix.node >= 20
+        run: npm run ci-mongoose9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,4 @@ jobs:
       - run: npm run ci-mongoose6
       - run: npm run ci-mongoose7
       - run: npm run ci-mongoose8
+      - run: npm run ci-mongoose9

--- a/README.md
+++ b/README.md
@@ -377,6 +377,10 @@ For more information, see [Performance Best Practices: Indexing](https://www.mon
 
 ## Changelog
 
+### 7.3
+
+- Add `mongoose` v9 support.
+
 ### 7.2
 
 - support MongoDB's `readConcern` in `book.ledger()`, `book.void()`, `book.listAccounts()` and `.entry.commit()`. #120 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "types/index.d.ts",
   "scripts": {
     "ci": "npm run build && npm run test",
+    "ci-mongoose9": "npm i mongoose@9 && npm run test:code",
     "ci-mongoose8": "npm i mongoose@8 && npm run test:code",
     "ci-mongoose7": "npm i mongoose@7 && npm run test:code",
     "ci-mongoose6": "npm i mongoose@6 && npm run test:code",
@@ -51,7 +52,7 @@
     "url": "https://github.com/flash-oss/medici/issues"
   },
   "dependencies": {
-    "mongoose": "5 - 8"
+    "mongoose": "5 - 9"
   },
   "homepage": "https://github.com/flash-oss/medici",
   "devDependencies": {


### PR DESCRIPTION
Medici currently declares `"mongoose": "5 - 8"`. When an application upgrades to Mongoose v9, npm installs two separate Mongoose copies (one for Medici, one for the app). Each instance has its own `mongoose.connection` singleton, so the app's `mongoose.connect()` never reaches the Mongoose copy Medici imports, and Medici's first call to `mongoose.connection.startSession()` fails with `MongooseError: Connection operation buffering timed out after 10000ms`.

This change widens the declared Mongoose range to `"5 - 9"`, adds a `ci-mongoose9` npm script, and wires it into CI alongside the existing v5/v6/v7/v8 matrix. No source changes were required, matching the v7/v8 support bump in commit d20f30d. Verified out-of-tree by forcing Medici onto Mongoose 9 via `overrides` in a downstream application: full test suite and production workloads pass with no behavioural regressions.

Fixes #123